### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ session.upload_progress.min_freq = "1"
 ; Also make certain 'upload_tmp_dir' is writeable
 ```
 
-###Composer###
+### Composer ###
 
 ```json
 {


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
